### PR TITLE
feat: update alert ui & make reusable button

### DIFF
--- a/bowwowcare/src/components/Alert.js
+++ b/bowwowcare/src/components/Alert.js
@@ -1,17 +1,31 @@
 import React from 'react';
 import { CiCircleAlert } from "react-icons/ci";
 
-function Alert({ open, handleOpen, content }) {
+
+function Alert({ open, handleOpen, content, handleSubmit }) {
     return (
         <div>
             {open ? (
                 <div className="fixed top-0 left-0 w-full h-screen bg-neutral-500/50 flex justify-center items-center">
                     <div className="px-4 pt-8 pb-6 w-11/12 bg-white rounded-md flex flex-col items-center">
                         <CiCircleAlert size="3rem" />
-                        <div className="text-center py-4">{content}</div>
-                        <button className="h-12 mt-4 w-full font-bold rounded-md bg-main-color text-white text-center" onClick={handleOpen}>
-                            확인
-                        </button>
+                        <div className="text-center py-4 whitespace-pre mb-2">{content}</div>
+                        
+                        {handleSubmit ? (
+                            <div className="flex justify-between space-x-4 w-full">
+                                <button onClick={handleOpen} className="h-12 mt-4 w-full font-bold border border-gray text-main-color text-center">
+                                    취소
+                                </button>
+                                <button onClick={handleSubmit} className="h-12 mt-4 w-full font-bold rounded-md bg-main-color text-white text-center">
+                                    확인
+                                </button>
+                            </div>
+                        ) : (
+                            <button onClick={handleOpen} className="h-12 mt-4 w-full font-bold rounded-md bg-main-color text-white text-center">
+                                확인
+                            </button>
+                        )}
+                        
                     </div>
                 </div>
             ) : null}

--- a/bowwowcare/src/components/Alert.js
+++ b/bowwowcare/src/components/Alert.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CiCircleAlert } from "react-icons/ci";
-
+import Button from "./Button";
 
 function Alert({ open, handleOpen, content, handleSubmit }) {
     return (
@@ -9,21 +9,21 @@ function Alert({ open, handleOpen, content, handleSubmit }) {
                 <div className="fixed top-0 left-0 w-full h-screen bg-neutral-500/50 flex justify-center items-center">
                     <div className="px-4 pt-8 pb-6 w-11/12 bg-white rounded-md flex flex-col items-center">
                         <CiCircleAlert size="3rem" />
-                        <div className="text-center py-4 whitespace-pre mb-2">{content}</div>
+                        <div className="text-center py-4 whitespace-pre">{content}</div>
                         
                         {handleSubmit ? (
                             <div className="flex justify-between space-x-4 w-full">
-                                <button onClick={handleOpen} className="h-12 mt-4 w-full font-bold border border-gray text-main-color text-center">
+                                <Button onClick={handleOpen} borderColor="gray" textColor="main-color" bgColor="none">
                                     취소
-                                </button>
-                                <button onClick={handleSubmit} className="h-12 mt-4 w-full font-bold rounded-md bg-main-color text-white text-center">
+                                </Button>
+                                <Button onClick={handleSubmit}>
                                     확인
-                                </button>
+                                </Button>
                             </div>
                         ) : (
-                            <button onClick={handleOpen} className="h-12 mt-4 w-full font-bold rounded-md bg-main-color text-white text-center">
+                            <Button onClick={handleOpen}>
                                 확인
-                            </button>
+                            </Button>
                         )}
                         
                     </div>

--- a/bowwowcare/src/components/Button.js
+++ b/bowwowcare/src/components/Button.js
@@ -1,0 +1,9 @@
+function Button ({size, bgColor="main-color", textColor="white", borderColor="none", children, onClick}) {
+    return (
+        <button onClick={onClick} className={`h-12 w-full font-bold rounded-md bg-${bgColor} border border-${borderColor} text-${textColor} text-center`}>
+            {children}
+        </button>
+    )
+};
+
+export default Button;

--- a/bowwowcare/src/views/SolutionPage/SolutionPage.js
+++ b/bowwowcare/src/views/SolutionPage/SolutionPage.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import Header from "../../components/Header";
 import Solution from "./Sections/Solution";
@@ -8,6 +8,7 @@ import Alert from "../../components/Alert";
 
 function SolutionPage() {
   const location = useLocation();
+  const navigate = useNavigate();
   const [answer, setAnswer] = useState({});
   const [emotion, setEmotion] = useState();
   const [open, setOpen] = useState(false);
@@ -25,10 +26,14 @@ function SolutionPage() {
   }
 
   const handleSaveResults = (e) => {
-    setAlertMessage("로그인이 필요한 서비스입니다");
+    setAlertMessage("로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?");
     handleOpen();
     // TODO: POST results
   }
+
+  const handleLogin = (e) => {
+		navigate("/login");
+	}
 
   return (
     <div className="container mx-auto px-8 w-screen h-screen">
@@ -45,14 +50,14 @@ function SolutionPage() {
         </div>
         <div className="w-full">
             <button 
-                className="h-12 w-full font-bold rounded-md bg-main-color text-white text-center" 
-                onClick={handleSaveResults}
+              className="h-12 w-full font-bold rounded-md bg-main-color text-white text-center" 
+              onClick={handleSaveResults}
             >
-                결과 저장하기
+              결과 저장하기
             </button>
         </div>
       </div>
-      <Alert open={open} handleOpen={handleOpen} content={alertMessage} />
+      <Alert open={open} handleOpen={handleOpen} content={alertMessage} handleSubmit={handleLogin} />
     </div>
   );
 }

--- a/bowwowcare/src/views/SolutionPage/SolutionPage.js
+++ b/bowwowcare/src/views/SolutionPage/SolutionPage.js
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import Header from "../../components/Header";
 import Solution from "./Sections/Solution";
 import Alert from "../../components/Alert";
+import Button from "../../components/Button";
 
 
 function SolutionPage() {
@@ -49,12 +50,7 @@ function SolutionPage() {
           })}
         </div>
         <div className="w-full">
-            <button 
-              className="h-12 w-full font-bold rounded-md bg-main-color text-white text-center" 
-              onClick={handleSaveResults}
-            >
-              결과 저장하기
-            </button>
+            <Button onClick={handleSaveResults}>결과 저장하기</Button>
         </div>
       </div>
       <Alert open={open} handleOpen={handleOpen} content={alertMessage} handleSubmit={handleLogin} />


### PR DESCRIPTION
`Alert` 컴포넌트
- `handleSubmit`이 있으면, 취소 버튼과 확인 버튼으로 나뉨
- `handleSubmit`이 없으면, 확인 버튼만 있는 알림창

`Button` 컴포넌트
- 버튼을 재사용 가능하게 만듦
    - w-full bg-main-color text-white 버튼이 디폴트이고, 스타일 커스텀 가능 