### PR TITLE
update auth header & add server api url

### DIFF
--- a/bowwowcare/src/Config.js
+++ b/bowwowcare/src/Config.js
@@ -1,0 +1,1 @@
+export const API_URL = "http://localhost:8080/api/v1"

--- a/bowwowcare/src/services/auth-header.js
+++ b/bowwowcare/src/services/auth-header.js
@@ -2,7 +2,7 @@ export default function authHeader() {
     const user = JSON.parse(localStorage.getItem("user"));
   
     if (user && user.token) {
-        return { Authorization: "Bearer " + user.token };
+        return { "X-AUTH-TOKEN": user.token };
     } else {
         return {};
     }


### PR DESCRIPTION
- `authHeader()` 업데이트!
    - 이제 `headers: authHeader()`로 사용하시면 됩니다 :)
- 전역 사용을 위해 서버 `API_URL` 따로 빼서 저장